### PR TITLE
Add warning about replacing configured/joined LoRa module

### DIFF
--- a/source/tutorials/connect-to-ttn.rst
+++ b/source/tutorials/connect-to-ttn.rst
@@ -340,6 +340,22 @@ incorrect LoRa module settings, e.g., mismatched DevEUI, AppEui, or AppKey. If
 your joins fail repeatedly, try resetting the LoRa modem to factory defaults,
 reboot the device, and follow the configuration steps mentioned earlier.
 
+.. warning::
+
+    All LoRa module settings, as well as the keys generated during OTAA join are
+    stored in the internal flash memory **of the LoRa module**. If you replace
+    the LoRa module, you will have to configure and join the device to TTN again.
+    
+    Also, connecting a previously joined LoRa module to a new Core module with
+    different firmware can be problematic if the firmware uses different payload
+    format. Since the identity of the device (from TTN point of view) is in the
+    LoRa module and not in the Core module, TTN may apply old payload formatters
+    to the new device.
+    
+    For the above reasons, we recommend to always reset the LoRa module to
+    factory defaults with ``AT$FRESET`` if the module is being replaced or
+    reconnected to another Core module.
+
 Upload Payload Formatter
 ------------------------
 

--- a/source/tutorials/connect-to-ttn.rst
+++ b/source/tutorials/connect-to-ttn.rst
@@ -342,15 +342,15 @@ reboot the device, and follow the configuration steps mentioned earlier.
 
 .. warning::
 
-    All LoRa module settings, as well as the keys generated during OTAA join are
+    All LoRa module settings as well as the keys generated during OTAA join are
     stored in the internal flash memory **of the LoRa module**. If you replace
     the LoRa module, you will have to configure and join the device to TTN again.
     
     Also, connecting a previously joined LoRa module to a new Core module with
-    different firmware can be problematic if the firmware uses different payload
-    format. Since the identity of the device (from TTN point of view) is in the
-    LoRa module and not in the Core module, TTN may apply old payload formatters
-    to the new device.
+    a different firmware can be problematic if the firmware uses an incompatible
+    payload format. Since the identity of the device (from TTN point of view) is
+    tied to the LoRa module and not to the Core module, TTN may apply incorrect
+    (old) payload formatters to the new device.
     
     For the above reasons, we recommend to always reset the LoRa module to
     factory defaults with ``AT$FRESET`` if the module is being replaced or


### PR DESCRIPTION
Replacing or moving a previously configured and joined LoRa module can be tricky since all configuration and session keys are stored in the LoRa module and not in the Core module. Thus, the identity of the Hardwario from TTN point of view is ultimately tied to the LoRa module and not to the Core module as one might expect.

Warn people about this and recommend to reset the LoRa module to factory defaults upon replacing or moving the module.